### PR TITLE
Add initial React Native skeleton for MindGuard

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+node_modules/
+android/
+ios/
+package-lock.json

--- a/README.md
+++ b/README.md
@@ -1,1 +1,12 @@
-# mindguard-demo
+# MindGuard React Native
+
+This is a starter project implementing the basic navigation flow for the **MindGuard** mobile application. The app includes authentication screens and a tab layout for the main features.
+
+## Available Scripts
+
+- `npm install` – install dependencies
+- `npm run start` – start Metro bundler
+- `npm run ios` – run on iOS simulator
+- `npm run android` – run on Android emulator
+
+The project uses React Navigation and bare React Native components to keep the example simple.

--- a/app.json
+++ b/app.json
@@ -1,0 +1,4 @@
+{
+  "name": "mindguard",
+  "displayName": "MindGuard"
+}

--- a/babel.config.js
+++ b/babel.config.js
@@ -1,0 +1,6 @@
+module.exports = function(api) {
+  api.cache(true);
+  return {
+    presets: ['module:metro-react-native-babel-preset'],
+  };
+};

--- a/index.js
+++ b/index.js
@@ -1,0 +1,5 @@
+import { AppRegistry } from 'react-native';
+import App from './src/App';
+import { name as appName } from './app.json';
+
+AppRegistry.registerComponent(appName, () => App);

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,0 +1,4 @@
+module.exports = {
+  preset: 'react-native',
+  moduleFileExtensions: ['ts', 'tsx', 'js', 'jsx', 'json', 'node'],
+};

--- a/package.json
+++ b/package.json
@@ -1,0 +1,30 @@
+{
+  "name": "mindguard",
+  "version": "0.0.1",
+  "private": true,
+  "scripts": {
+    "start": "react-native start",
+    "android": "react-native run-android",
+    "ios": "react-native run-ios",
+    "test": "jest --passWithNoTests"
+  },
+  "dependencies": {
+    "react": "18.2.0",
+    "react-native": "0.73.6",
+    "@react-navigation/native": "^6.1.7",
+    "@react-navigation/native-stack": "^6.9.12",
+    "@react-navigation/bottom-tabs": "^6.5.16",
+    "react-native-gesture-handler": "^2.14.2",
+    "react-native-reanimated": "^3.7.0",
+    "react-native-safe-area-context": "^4.8.1",
+    "react-native-screens": "^3.30.0"
+  },
+  "devDependencies": {
+    "@babel/core": "^7.21.5",
+    "@types/react": "^18.2.0",
+    "@types/react-native": "^0.73.0",
+    "jest": "^29.6.1",
+    "react-test-renderer": "18.2.0",
+    "typescript": "^5.4.0"
+  }
+}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,0 +1,18 @@
+import React, { useState } from 'react';
+import { NavigationContainer } from '@react-navigation/native';
+import AuthNavigator from './navigation/AuthNavigator';
+import MainNavigator from './navigation/MainNavigator';
+
+export default function App() {
+  const [isLoggedIn, setLoggedIn] = useState(false);
+
+  return (
+    <NavigationContainer>
+      {isLoggedIn ? (
+        <MainNavigator onLogout={() => setLoggedIn(false)} />
+      ) : (
+        <AuthNavigator onLogin={() => setLoggedIn(true)} />
+      )}
+    </NavigationContainer>
+  );
+}

--- a/src/navigation/AuthNavigator.tsx
+++ b/src/navigation/AuthNavigator.tsx
@@ -1,0 +1,29 @@
+import React from 'react';
+import { createNativeStackNavigator } from '@react-navigation/native-stack';
+import LoginScreen from '../screens/Authentication/LoginScreen';
+import RegisterScreen from '../screens/Authentication/RegisterScreen';
+import ForgotPasswordScreen from '../screens/Authentication/ForgotPasswordScreen';
+
+export type AuthStackParamList = {
+  Login: undefined;
+  Register: undefined;
+  ForgotPassword: undefined;
+};
+
+const Stack = createNativeStackNavigator<AuthStackParamList>();
+
+interface Props {
+  onLogin: () => void;
+}
+
+export default function AuthNavigator({ onLogin }: Props) {
+  return (
+    <Stack.Navigator>
+      <Stack.Screen name="Login" options={{ headerShown: false }}>
+        {() => <LoginScreen onLogin={onLogin} />}
+      </Stack.Screen>
+      <Stack.Screen name="Register" component={RegisterScreen} />
+      <Stack.Screen name="ForgotPassword" component={ForgotPasswordScreen} />
+    </Stack.Navigator>
+  );
+}

--- a/src/navigation/MainNavigator.tsx
+++ b/src/navigation/MainNavigator.tsx
@@ -1,0 +1,32 @@
+import React from 'react';
+import { createBottomTabNavigator } from '@react-navigation/bottom-tabs';
+import DashboardScreen from '../screens/DashboardScreen';
+import BuddyScreen from '../screens/BuddyScreen';
+import SosScreen from '../screens/SosScreen';
+import ProfileScreen from '../screens/ProfileScreen';
+
+export type MainTabParamList = {
+  Dashboard: undefined;
+  Buddy: undefined;
+  SOS: undefined;
+  Profile: undefined;
+};
+
+const Tab = createBottomTabNavigator<MainTabParamList>();
+
+interface Props {
+  onLogout: () => void;
+}
+
+export default function MainNavigator({ onLogout }: Props) {
+  return (
+    <Tab.Navigator>
+      <Tab.Screen name="Dashboard" component={DashboardScreen} />
+      <Tab.Screen name="Buddy" component={BuddyScreen} />
+      <Tab.Screen name="SOS" component={SosScreen} />
+      <Tab.Screen name="Profile">
+        {() => <ProfileScreen onLogout={onLogout} />}
+      </Tab.Screen>
+    </Tab.Navigator>
+  );
+}

--- a/src/screens/Authentication/ForgotPasswordScreen.tsx
+++ b/src/screens/Authentication/ForgotPasswordScreen.tsx
@@ -1,0 +1,39 @@
+import React, { useState } from 'react';
+import { View, Text, TextInput, Button, StyleSheet } from 'react-native';
+
+export default function ForgotPasswordScreen() {
+  const [email, setEmail] = useState('');
+
+  return (
+    <View style={styles.container}>
+      <Text style={styles.title}>Reset Password</Text>
+      <TextInput
+        placeholder="Email"
+        value={email}
+        onChangeText={setEmail}
+        style={styles.input}
+      />
+      <Button title="Send Reset Link" onPress={() => {}} />
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    justifyContent: 'center',
+    padding: 16,
+  },
+  title: {
+    fontSize: 24,
+    marginBottom: 12,
+    textAlign: 'center',
+  },
+  input: {
+    borderWidth: 1,
+    borderColor: '#ccc',
+    padding: 8,
+    marginBottom: 12,
+    borderRadius: 4,
+  },
+});

--- a/src/screens/Authentication/LoginScreen.tsx
+++ b/src/screens/Authentication/LoginScreen.tsx
@@ -1,0 +1,63 @@
+import React, { useState } from 'react';
+import { View, Text, TextInput, Button, StyleSheet, TouchableOpacity } from 'react-native';
+
+interface Props {
+  onLogin: () => void;
+}
+
+export default function LoginScreen({ onLogin }: Props) {
+  const [email, setEmail] = useState('');
+  const [password, setPassword] = useState('');
+
+  return (
+    <View style={styles.container}>
+      <Text style={styles.logo}>MindGuard</Text>
+      <TextInput
+        placeholder="Email"
+        value={email}
+        onChangeText={setEmail}
+        style={styles.input}
+      />
+      <TextInput
+        placeholder="Password"
+        secureTextEntry
+        value={password}
+        onChangeText={setPassword}
+        style={styles.input}
+      />
+      <Button title="Log In" onPress={onLogin} />
+      <TouchableOpacity>
+        <Text style={styles.link}>Forgot Password?</Text>
+      </TouchableOpacity>
+      <TouchableOpacity>
+        <Text style={styles.link}>Don't have an account? Sign Up</Text>
+      </TouchableOpacity>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    justifyContent: 'center',
+    padding: 16,
+  },
+  logo: {
+    fontSize: 32,
+    fontWeight: 'bold',
+    marginBottom: 24,
+    textAlign: 'center',
+  },
+  input: {
+    borderWidth: 1,
+    borderColor: '#ccc',
+    padding: 8,
+    marginBottom: 12,
+    borderRadius: 4,
+  },
+  link: {
+    marginTop: 12,
+    color: 'blue',
+    textAlign: 'center',
+  },
+});

--- a/src/screens/Authentication/RegisterScreen.tsx
+++ b/src/screens/Authentication/RegisterScreen.tsx
@@ -1,0 +1,71 @@
+import React, { useState } from 'react';
+import { View, Text, TextInput, Button, StyleSheet, TouchableOpacity } from 'react-native';
+
+export default function RegisterScreen() {
+  const [name, setName] = useState('');
+  const [email, setEmail] = useState('');
+  const [password, setPassword] = useState('');
+  const [confirm, setConfirm] = useState('');
+
+  return (
+    <View style={styles.container}>
+      <Text style={styles.logo}>MindGuard</Text>
+      <TextInput
+        placeholder="Full Name"
+        value={name}
+        onChangeText={setName}
+        style={styles.input}
+      />
+      <TextInput
+        placeholder="Email"
+        value={email}
+        onChangeText={setEmail}
+        style={styles.input}
+      />
+      <TextInput
+        placeholder="Password"
+        secureTextEntry
+        value={password}
+        onChangeText={setPassword}
+        style={styles.input}
+      />
+      <TextInput
+        placeholder="Confirm Password"
+        secureTextEntry
+        value={confirm}
+        onChangeText={setConfirm}
+        style={styles.input}
+      />
+      <Button title="Create Account" onPress={() => {}} />
+      <TouchableOpacity>
+        <Text style={styles.link}>Already have an account? Log In</Text>
+      </TouchableOpacity>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    justifyContent: 'center',
+    padding: 16,
+  },
+  logo: {
+    fontSize: 32,
+    fontWeight: 'bold',
+    marginBottom: 24,
+    textAlign: 'center',
+  },
+  input: {
+    borderWidth: 1,
+    borderColor: '#ccc',
+    padding: 8,
+    marginBottom: 12,
+    borderRadius: 4,
+  },
+  link: {
+    marginTop: 12,
+    color: 'blue',
+    textAlign: 'center',
+  },
+});

--- a/src/screens/BuddyScreen.tsx
+++ b/src/screens/BuddyScreen.tsx
@@ -1,0 +1,24 @@
+import React from 'react';
+import { View, Text, StyleSheet, Button } from 'react-native';
+
+export default function BuddyScreen() {
+  return (
+    <View style={styles.container}>
+      <Text style={styles.title}>Buddy</Text>
+      <Text>Manage your accountability partner.</Text>
+      <Button title="Invite Buddy" onPress={() => {}} />
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  title: {
+    fontSize: 24,
+    marginBottom: 16,
+  },
+});

--- a/src/screens/DashboardScreen.tsx
+++ b/src/screens/DashboardScreen.tsx
@@ -1,0 +1,24 @@
+import React from 'react';
+import { View, Text, StyleSheet, Button } from 'react-native';
+
+export default function DashboardScreen() {
+  return (
+    <View style={styles.container}>
+      <Text style={styles.title}>Dashboard</Text>
+      <Text>Your habits will appear here.</Text>
+      <Button title="Add Habit" onPress={() => {}} />
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  title: {
+    fontSize: 24,
+    marginBottom: 16,
+  },
+});

--- a/src/screens/ProfileScreen.tsx
+++ b/src/screens/ProfileScreen.tsx
@@ -1,0 +1,28 @@
+import React from 'react';
+import { View, Text, StyleSheet, Button } from 'react-native';
+
+interface Props {
+  onLogout: () => void;
+}
+
+export default function ProfileScreen({ onLogout }: Props) {
+  return (
+    <View style={styles.container}>
+      <Text style={styles.title}>Profile</Text>
+      <Text>Your account details.</Text>
+      <Button title="Logout" onPress={onLogout} />
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  title: {
+    fontSize: 24,
+    marginBottom: 16,
+  },
+});

--- a/src/screens/SosScreen.tsx
+++ b/src/screens/SosScreen.tsx
@@ -1,0 +1,24 @@
+import React from 'react';
+import { View, Text, StyleSheet, Button } from 'react-native';
+
+export default function SosScreen() {
+  return (
+    <View style={styles.container}>
+      <Text style={styles.title}>SOS</Text>
+      <Text>Quick access to coping tools.</Text>
+      <Button title="Start Meditation" onPress={() => {}} />
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  title: {
+    fontSize: 24,
+    marginBottom: 16,
+  },
+});

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,15 @@
+{
+  "compilerOptions": {
+    "allowJs": true,
+    "target": "es2015",
+    "module": "esnext",
+    "jsx": "react",
+    "lib": ["es2015", "dom"],
+    "skipLibCheck": true,
+    "strict": false,
+    "noEmit": true,
+    "esModuleInterop": true
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules"]
+}


### PR DESCRIPTION
## Summary
- add React Native project configuration
- implement navigation with Auth and main tabs
- add placeholder screens for registration, login, dashboard, buddy, SOS and profile
- update README with setup instructions

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687a784e5dc0832a9e713737d7eb8d9c